### PR TITLE
Convert to stateful set and add volume paths and grpc ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tls.key
 
 /helmfiles/*
 !/helmfiles/helmfile.yaml
+/volumes/*
+!/volumes/.gitkeep

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This project is still in its infancy, so we don't have a lot of configuration op
 But you can create your own `helmfile.yaml` in the `helmfiles` folder with the following content:
 
 ```yaml
-# helmfiles/helmfile.yaml
-# All files except helmfile.yaml are ignored by git
+# helmfiles/my-helmfile.yaml
+# All files except helmfile.yaml are ignored by git, so you can add them safely.
 releases:
     - name: bitcoind
       chart: ../charts/bitcoind # these should point to the charts you want to use.
@@ -58,26 +58,30 @@ releases:
       chart: ../charts/lnd # these should point to the charts you want to use.
       ## Set additional values or override existing ones
       ## original values: charts/bitcoind/values.yaml
-      # values:
-      #   - ./anywhere/lnd/values.yaml
+      values:
+          - gRPCNodePort: 30009
+          - lndHostPath: {{env "PWD"}}/volumes/lnd1
     - name: lnd2
       chart: ../charts/lnd # these should point to the charts you want to use.
       ## Set additional values or override existing ones
       ## original values: charts/lnd/values.yaml
-      # values:
-      #   - ./anywhere/lnd/values.yaml
+      values:
+          - gRPCNodePort: 30010
+          - lndHostPath: {{env "PWD"}}/volumes/lnd2
     - name: lnd3
       chart: ../charts/lnd # these should point to the charts you want to use.
       ## Set additional values or override existing ones
       ## original values: charts/lnd/values.yaml
-      # values:
-      #   - ./anywhere/lnd/values.yaml
+      values:
+          - gRPCNodePort: 30011
+          - lndHostPath: {{env "PWD"}}/volumes/lnd3
     - name: lnd4
       chart: ../charts/lnd # these should point to the charts you want to use.
       ## Set additional values or override existing ones
       ## original values: charts/lnd/values.yaml
-      # values:
-      #   - ./anywhere/lnd/values.yaml
+      values:
+          - gRPCNodePort: 30012
+          - lndHostPath: {{env "PWD"}}/volumes/lnd4
 ```
 
 ## Why is this important?

--- a/charts/bitcoind/templates/deployment.yaml
+++ b/charts/bitcoind/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "bitcoind.fullname" . }}
   labels:
@@ -16,7 +16,13 @@ spec:
     spec:
       volumes:
         - name: cookie
+          {{- if .Values.bitcoindHostPath }}
+          hostPath:
+            path: {{ .Values.bitcoindHostPath }}
+            type: DirectoryOrCreate
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lnd/templates/deployment.yaml
+++ b/charts/lnd/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "lnd.fullname" . }}
   labels:
@@ -18,7 +18,13 @@ spec:
         runAsUser: 0
       volumes:
         - name: tlsmacaroon
+          {{- if .Values.lndHostPath }}
+          hostPath:
+            path: {{ .Values.lndHostPath }}
+            type: DirectoryOrCreate
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lnd/templates/service.yaml
+++ b/charts/lnd/templates/service.yaml
@@ -21,3 +21,31 @@ spec:
       port: {{ .Values.clientPort }}
   selector:
     {{- include "lnd.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lnd.fullname" . }}
+  labels:
+    {{- include "lnd.labels" . | nindent 4 }}
+spec:
+  type: NodePort
+  ports:
+    - name: peer
+      targetPort: peer
+      port: {{ .Values.port }}
+    - name: grpc
+      targetPort: grpc
+      port: {{ .Values.gRPCPort }}
+      {{- if .Values.gRPCNodePort }}
+      nodePort: {{ .Values.gRPCNodePort }}
+      {{- end }}
+    - name: rest
+      targetPort: rest
+      port: {{ .Values.restPort }}
+    - name: client
+      targetPort: client
+      port: {{ .Values.clientPort }}
+  selector:
+    {{- include "lnd.selectorLabels" . | nindent 4 }}
+

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -24,6 +24,7 @@ zmqPubTxPort: 28333
 
 port: 9735
 gRPCPort: 10009
+#gRPCNodePort: 30009 # has to be above 30,000
 restPort: 8080
 
 clientPort: 8181

--- a/helmfiles/helmfile.yaml
+++ b/helmfiles/helmfile.yaml
@@ -2,11 +2,25 @@
 releases:
     - name: bitcoind
       chart: ../charts/bitcoind
+      values:
+          - bitcoindHostPath: {{env "PWD"}}/volumes/bitcoind
     - name: lnd1
       chart: ../charts/lnd
+      values:
+          - gRPCNodePort: 30009
+          - lndHostPath: {{env "PWD"}}/volumes/lnd1
     - name: lnd2
       chart: ../charts/lnd
+      values:
+          - gRPCNodePort: 30010
+          - lndHostPath: {{env "PWD"}}/volumes/lnd2
     - name: lnd3
       chart: ../charts/lnd
+      values:
+          - gRPCNodePort: 30011
+          - lndHostPath: {{env "PWD"}}/volumes/lnd3
     - name: lnd4
       chart: ../charts/lnd
+      values:
+          - gRPCNodePort: 30012
+          - lndHostPath: {{env "PWD"}}/volumes/lnd4


### PR DESCRIPTION
I converted the deployments to a stateful set so that we can set a volume directory to access macaroons etc. I also added NodePort as we discussed.