### PR TITLE
Fix kube cp command on windows

### DIFF
--- a/pkg/network/kube.go
+++ b/pkg/network/kube.go
@@ -3,12 +3,22 @@ package network
 import (
 	"encoding/json"
 	"os/exec"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 )
 
 func kubeCP(kubeconfig string, source string, destination string) error {
+
+	//on windows remove the C: from the path as kubeCP doesn't support a path with ":"
+	if strings.HasPrefix(strings.ToLower(source), "c:") {
+		source = source[2:]
+	}
+	if strings.HasPrefix(strings.ToLower(destination), "c:") {
+		destination = destination[2:]
+	}
+
 	//TODO: sanitise inputs here
 	kubectlCmd := exec.Command( //nolint:gosec
 		"kubectl",


### PR DESCRIPTION
Kubectl cp can't have ":" in file path, because it thinks it's a pod. So windows C:\ paths don't work.
https://github.com/kubernetes/kubectl/issues/1225

So i removed the C: from beginning of path and now it works on windows too.