### PR TITLE
Configurable kube namespace

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           go-version: ">=1.21.0"
       - name: Run E2E Tests
-        run: go test -run ^TestMain$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
+        run: go test -run ^TestMainExample$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
       # setup ssh access if e2e job fails
       # - name: Setup upterm session
       #   if: always() && (steps.e2e.outcome == 'failure')

--- a/README.md
+++ b/README.md
@@ -109,13 +109,28 @@ To destroy the network run:
     # have bitcoind generate some blocks and pay itself the block reward
     ./scaling-lightning generate -n bitcoind
 
+#### Using different Kubernetes namespaces
+
+By default, `sl` namespace is used. If you want to use a different namespace, you can specify it in the helmfile.
+
+If you use multiple namespaces, make sure that the endpoints that are used are not overlapping!
+
+    # Download example helmfile that has a custom namespace
+    wget https://raw.githubusercontent.com/scaling-lightning/scaling-lightning/main/examples/helmfiles/local-custom-namespace.yaml
+
+    # Create the nework normally, the namespace is read from the helmfile
+    ./scaling-lightning create -f local-custom-namespace.yaml
+
+    # In the following commands use the --namespace flag to interact with the created namespace (otherwise it will default to sl)
+    ./scaling-lightning --namespace my-other-sl list
+
 ### Run the above from code instead of CLI
 
 See [examples/go/example_test.go](examples/go/example_test.go). This test takes around 3 minutes to pass on an M1 Macbook Pro so you may need to adjust your test runner's default timeout.
 
 Example go test command with extra timeout:
 
-    go test -run ^TestMain$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
+    go test -run ^TestMainExample$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
 
 ### Helpful Kubernetes commands
 
@@ -144,7 +159,7 @@ Example go test command with extra timeout:
     # view loadbalancer public ip from traefik
     kubectl -n sl-traefik get services
 
-    # destroy all scaling lightning nodes
+    # destroy all scaling lightning nodes in the default namespace
     kubectl delete namespace sl
 
     # uninstall traefik

--- a/cmd/scalinglightning/channelbalance.go
+++ b/cmd/scalinglightning/channelbalance.go
@@ -17,7 +17,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
 			nodeName := cmd.Flag("node").Value.String()
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/connectiondetails.go
+++ b/cmd/scalinglightning/connectiondetails.go
@@ -27,7 +27,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/connectpeer.go
+++ b/cmd/scalinglightning/connectpeer.go
@@ -18,7 +18,7 @@ func init() {
 			processDebugFlag(cmd)
 			connectpeerFromName := cmd.Flag("from").Value.String()
 			connectpeerToName := cmd.Flag("to").Value.String()
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/create.go
+++ b/cmd/scalinglightning/create.go
@@ -16,9 +16,21 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
 			helmfile := cmd.Flag("helmfile").Value.String()
+
+			// Namespace flag should not be used with create, since namespace is read from the helmfile
+			if rootCmd.Flag("namespace").Changed {
+				fmt.Println("Cannot create. Do not use namespace flag with create. Instead specify the namespace in the helmfile.")
+				return
+			}
+
 			fmt.Println("Creating and starting the network")
-			slnetwork := sl.NewSLNetwork(helmfile, kubeConfigPath, sl.Regtest)
-			err := slnetwork.CreateAndStart()
+			slnetwork, err := sl.NewSLNetworkWithoutNamespace(helmfile, kubeConfigPath, sl.Regtest)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			err = slnetwork.CreateAndStart()
 			if err != nil {
 				fmt.Println(err.Error())
 			}

--- a/cmd/scalinglightning/createinvoice.go
+++ b/cmd/scalinglightning/createinvoice.go
@@ -22,7 +22,7 @@ func init() {
 				fmt.Println("Amount must be a valid number")
 				return
 			}
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/destroy.go
+++ b/cmd/scalinglightning/destroy.go
@@ -15,9 +15,15 @@ func init() {
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
-			fmt.Println("Destroying the network")
-			slnetwork := sl.NewSLNetwork("", kubeConfigPath, sl.Regtest)
-			err := slnetwork.Destroy()
+
+			fmt.Printf("Destroying the network '%v'\n", namespace)
+			slnetwork, err := sl.NewSLNetwork("", kubeConfigPath, sl.Regtest, namespace)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			err = slnetwork.Destroy()
 			if err != nil {
 				fmt.Println(err.Error())
 			}

--- a/cmd/scalinglightning/generate.go
+++ b/cmd/scalinglightning/generate.go
@@ -23,7 +23,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/list.go
+++ b/cmd/scalinglightning/list.go
@@ -16,7 +16,7 @@ func init() {
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/openchannel.go
+++ b/cmd/scalinglightning/openchannel.go
@@ -24,7 +24,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/payinvoice.go
+++ b/cmd/scalinglightning/payinvoice.go
@@ -18,7 +18,7 @@ func init() {
 			processDebugFlag(cmd)
 			nodeName := cmd.Flag("node").Value.String()
 			invoice := cmd.Flag("invoice").Value.String()
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/pubkey.go
+++ b/cmd/scalinglightning/pubkey.go
@@ -17,7 +17,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
 			pubkeyNodeName := cmd.Flag("node").Value.String()
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/root.go
+++ b/cmd/scalinglightning/root.go
@@ -1,6 +1,7 @@
 package scalinglightning
 
 import (
+	"github.com/scaling-lightning/scaling-lightning/pkg/network"
 	"os"
 	"os/user"
 	"path"
@@ -13,6 +14,7 @@ import (
 var kubeConfigPath string //nolint:gochecknoglobals
 var apiHost string        //nolint:gochecknoglobals
 var apiPort uint16        //nolint:gochecknoglobals
+var namespace string      //nolint:gochecknoglobals
 
 var rootCmd = &cobra.Command{ //nolint:gochecknoglobals
 	Use:   "sl",
@@ -55,6 +57,8 @@ func init() {
 		StringVarP(&apiHost, "host", "H", "", "Host of the scaling-lightning API")
 	rootCmd.PersistentFlags().
 		Uint16VarP(&apiPort, "port", "p", 0, "Port of the scaling-lightning API")
+	rootCmd.PersistentFlags().
+		StringVarP(&namespace, "namespace", "N", network.DefaultNamespace, "Kubernetes namespace for the network")
 
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging")
 }

--- a/cmd/scalinglightning/send.go
+++ b/cmd/scalinglightning/send.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	var sendCmd = &cobra.Command{
 		Use:   "send",
-		Short: "Send on chain funds betwen nodes",
+		Short: "Send on chain funds between nodes",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
@@ -23,7 +23,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/start.go
+++ b/cmd/scalinglightning/start.go
@@ -27,7 +27,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/stop.go
+++ b/cmd/scalinglightning/stop.go
@@ -27,7 +27,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/walletbalance.go
+++ b/cmd/scalinglightning/walletbalance.go
@@ -16,7 +16,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			processDebugFlag(cmd)
 			balanceNodeName := cmd.Flag("node").Value.String()
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/cmd/scalinglightning/writeauthfiles.go
+++ b/cmd/scalinglightning/writeauthfiles.go
@@ -24,7 +24,7 @@ func init() {
 				return
 			}
 
-			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort)
+			slnetwork, err := sl.DiscoverRunningNetwork(kubeConfigPath, apiHost, apiPort, namespace)
 			if err != nil {
 				fmt.Printf(
 					"Problem with network discovery, is there a network running? Error: %v\n",

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -28,7 +28,7 @@ import (
 )
 
 // will need a longish (few mins) timeout
-func TestMain(t *testing.T) {
+func TestMainExample(t *testing.T) {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	assert := assert.New(t)
 	network := sl.NewSLNetwork("../helmfiles/public.yaml", "", sl.Regtest)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -52,7 +52,7 @@ releases:
       - image:
           tag: v23.05.1 # Version of CLN docker image to use
       - clientImage:
-          repository: cln-client # Use a specific image for sidecar container (usually used when developing the scaling lightning project itself)
+          repository: scalingln/cln-client # Use a specific image for sidecar container (usually used when developing the scaling lightning project itself)
           pullPolicy: IfNotPresent # K8s Pull Policy for sidecar image. IfNotPresent helps locate updated local images.
       - volume: # Optional: if specified will create a volume and data will be persisted between restarts and upgrades
           size: "1Gi" # Size of volume in kubernetes notation. Here 1 Gibibyte (1,073,741,824 bytes) is specified.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -92,13 +92,28 @@ To destroy the network run:
     # have bitcoind generate some blocks and pay itself the block reward
     ./scaling-lightning generate -n bitcoind
 
+#### Using different Kubernetes namespaces
+
+By default, `sl` namespace is used. If you want to use a different namespace, you can specify it in the helmfile.
+
+If you use multiple namespaces, make sure that the endpoints that are used are not overlapping!
+
+    # Download example helmfile that has a custom namespace
+    wget https://raw.githubusercontent.com/scaling-lightning/scaling-lightning/main/examples/helmfiles/local-custom-namespace.yaml
+
+    # Create the nework normally, the namespace is read from the helmfile
+    ./scaling-lightning create -f local-custom-namespace.yaml
+
+    # In the following commands use the --namespace flag to interact with the created namespace (otherwise it will default to sl)
+    ./scaling-lightning --namespace my-other-sl list
+
 ## Run the above from code instead of CLI
 
 See [examples/go/example_test.go](https://github.com/scaling-lightning/scaling-lightning/blob/main/examples/go/example_test.go). This test takes around 3 minutes to pass on an M1 Macbook Pro so you may need to adjust your test runner's default timeout.
 
 Example go test command with extra timeout:
 
-    go test -run ^TestMain$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
+    go test -run ^TestMainExample$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
 
 ## Helpful Kubernetes commands
 

--- a/docs/docs/how-to/run-on-github-actions.md
+++ b/docs/docs/how-to/run-on-github-actions.md
@@ -37,7 +37,7 @@ jobs:
         with:
           go-version: ">=1.21.0"
       - name: Run example test
-        run: go test -run ^TestMain$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
+        run: go test -run ^TestMainExample$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
 ```
 
 The [example test](https://github.com/scaling-lightning/scaling-lightning/blob/main/examples/go/example_test.go) can be found in our repo under examples/go.

--- a/examples/githubactions/runwithminikube.yml
+++ b/examples/githubactions/runwithminikube.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           go-version: ">=1.21.0"
       - name: Run example test
-        run: go test -run ^TestMain$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m
+        run: go test -run ^TestMainExample$ github.com/scaling-lightning/scaling-lightning/examples/go -count=1 -v -timeout=15m

--- a/examples/go/example_test.go
+++ b/examples/go/example_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 // will need a longish (few mins) timeout
-func TestMain(t *testing.T) {
+func TestMainExapmle(t *testing.T) {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	assert := assert.New(t)
-	network := sl.NewSLNetwork("../helmfiles/public.yaml", "", sl.Regtest)
-	err := network.CreateAndStart()
+	network, err := sl.NewSLNetwork("../helmfiles/public.yaml", "", sl.Regtest, sl.DefaultNamespace)
+	assert.NoError(err)
+
+	err = network.CreateAndStart()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Problem starting network")
 	}

--- a/examples/helmfiles/local-custom-namespace.yaml
+++ b/examples/helmfiles/local-custom-namespace.yaml
@@ -1,0 +1,30 @@
+# uses the local charts in the charts directory and images available locally
+# uses custom namespace (note that the endpoints are changed to avoid conflicts)
+releases:
+  - name: bitcoind
+    namespace: my-other-sl
+    chart: ../../charts/bitcoind
+    values:
+      - clientImage:
+          repository: bitcoind-client
+          pullPolicy: IfNotPresent
+      - autoGen: true
+      - rpcEntryPoint: endpoint27
+      - zmqPubBlockEntryPoint: endpoint28
+      - zmqPubTxEntryPoint: endpoint29
+  - name: cln1
+    namespace: my-other-sl
+    chart: ../../charts/cln
+    values:
+      - gRPCEntryPoint: endpoint20
+      - clientImage:
+          repository: cln-client
+          pullPolicy: IfNotPresent
+  - name: lnd1
+    namespace: my-other-sl
+    chart: ../../charts/lnd
+    values:
+      - clientImage:
+          repository: lnd-client
+          pullPolicy: IfNotPresent
+      - gRPCEntryPoint: endpoint21

--- a/examples/helmfiles/local.yaml
+++ b/examples/helmfiles/local.yaml
@@ -5,7 +5,7 @@ releases:
     chart: ../../charts/bitcoind
     values:
       - clientImage:
-          repository: bitcoind-client
+          repository: scalingln/bitcoind-client
           pullPolicy: IfNotPresent
       - autoGen: true
       - rpcEntryPoint: endpoint37
@@ -17,14 +17,14 @@ releases:
     values:
       - gRPCEntryPoint: endpoint1
       - clientImage:
-          repository: cln-client
+          repository: scalingln/cln-client
           pullPolicy: IfNotPresent
   - name: cln2
     namespace: sl
     chart: ../../charts/cln
     values:
       - clientImage:
-          repository: cln-client
+          repository: scalingln/cln-client
           pullPolicy: IfNotPresent
       - gRPCEntryPoint: endpoint2
   - name: lnd1
@@ -32,7 +32,7 @@ releases:
     chart: ../../charts/lnd
     values:
       - clientImage:
-          repository: lnd-client
+          repository: scalingln/lnd-client
           pullPolicy: IfNotPresent
       - gRPCEntryPoint: endpoint3
   - name: lnd2
@@ -40,6 +40,6 @@ releases:
     chart: ../../charts/lnd
     values:
       - clientImage:
-          repository: lnd-client
+          repository: scalingln/lnd-client
           pullPolicy: IfNotPresent
       - gRPCEntryPoint: endpoint4

--- a/examples/helmfiles/localcustomnamespace.yaml
+++ b/examples/helmfiles/localcustomnamespace.yaml
@@ -1,12 +1,12 @@
 # uses the local charts in the charts directory and images available locally
-# uses custom namespace (note that the endpoints are changed to avoid conflicts)
+# uses custom namespace (note that the endpoints are different from other helmfiles to avoid overlaps)
 releases:
   - name: bitcoind
     namespace: my-other-sl
     chart: ../../charts/bitcoind
     values:
       - clientImage:
-          repository: bitcoind-client
+          repository: scalingln/bitcoind-client
           pullPolicy: IfNotPresent
       - autoGen: true
       - rpcEntryPoint: endpoint27
@@ -18,13 +18,13 @@ releases:
     values:
       - gRPCEntryPoint: endpoint20
       - clientImage:
-          repository: cln-client
+          repository: scalingln/cln-client
           pullPolicy: IfNotPresent
   - name: lnd1
     namespace: my-other-sl
     chart: ../../charts/lnd
     values:
       - clientImage:
-          repository: lnd-client
+          repository: scalingln/lnd-client
           pullPolicy: IfNotPresent
       - gRPCEntryPoint: endpoint21

--- a/pkg/bitcoinnode/bitcoinnode.go
+++ b/pkg/bitcoinnode/bitcoinnode.go
@@ -14,6 +14,7 @@ import (
 type BitcoinNode struct {
 	Name string
 	stdbitcoinclient.BitcoinClient
+	Namespace string
 }
 
 func (n *BitcoinNode) Generate(client stdbitcoinclient.BitcoinClient, commonClient stdcommonclient.CommonClient, numBlocks uint32) (hashes []string, err error) {
@@ -83,15 +84,15 @@ func (n *BitcoinNode) GetName() string {
 }
 
 func (n *BitcoinNode) GetConnectionPorts(kubeConfig string) ([]ConnectionPorts, error) {
-	rpcPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-rpc", kube.ModeHTTP)
+	rpcPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-rpc", kube.ModeHTTP, n.Namespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Getting endpoint for %v", n.Name)
 	}
-	zmqBlockPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-zmq-pub-block", kube.ModeTCP)
+	zmqBlockPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-zmq-pub-block", kube.ModeTCP, n.Namespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Getting endpoint for %v", n.Name)
 	}
-	zmqTxPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-zmq-pub-tx", kube.ModeTCP)
+	zmqTxPort, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-zmq-pub-tx", kube.ModeTCP, n.Namespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Getting endpoint for %v", n.Name)
 	}

--- a/pkg/bitcoinnode/bitcoinnode_test.go
+++ b/pkg/bitcoinnode/bitcoinnode_test.go
@@ -12,7 +12,9 @@ import (
 func TestBitcoinNode(t *testing.T) {
 	assert := assert.New(t)
 
-	bitcoinNode := &BitcoinNode{}
+	bitcoinNode := &BitcoinNode{
+		Namespace: "sl",
+	}
 
 	mockGrpcClient := common.NewMockCommonClient(t)
 	mockGrpcClient.On("Send", mock.Anything, mock.Anything).Return(&common.SendResponse{}, nil)

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -13,11 +13,10 @@ import (
 )
 
 const (
-	mainNamespace    = "sl"
 	traefikNamespace = "sl-traefik"
 )
 
-func KubeCP(kubeconfig string, source string, destination string) error {
+func KubeCP(kubeconfig string, source string, destination string, namespace string) error {
 
 	//on windows remove the C: from the path as kubeCP doesn't support a path with ":"
 	if strings.HasPrefix(strings.ToLower(source), "c:") {
@@ -33,7 +32,7 @@ func KubeCP(kubeconfig string, source string, destination string) error {
 		"--kubeconfig",
 		kubeconfig,
 		"-n",
-		mainNamespace,
+		namespace,
 		"cp",
 		source,
 		destination,
@@ -70,7 +69,7 @@ const (
 	ModeTCP
 )
 
-func GetEndpointForNode(kubeconfig string, ingressName string, mode endpointMode) (uint16, error) {
+func GetEndpointForNode(kubeconfig string, ingressName string, mode endpointMode, namespace string) (uint16, error) {
 	crd := "ingressroutetcps.traefik.containo.us"
 	if mode == ModeHTTP {
 		crd = "ingressroutes.traefik.io"
@@ -82,7 +81,7 @@ func GetEndpointForNode(kubeconfig string, ingressName string, mode endpointMode
 		"--kubeconfig",
 		kubeconfig,
 		"-n",
-		mainNamespace,
+		namespace,
 		"get",
 		crd,
 		ingressName,
@@ -141,14 +140,14 @@ func GetEndpointForNode(kubeconfig string, ingressName string, mode endpointMode
 	return 0, errors.New("Couldn't find port")
 }
 
-func Scale(kubeconfig string, deploymentName string, deploymentType string, replicas int) error {
+func Scale(kubeconfig string, deploymentName string, deploymentType string, replicas int, namespace string) error {
 	// TODO: sanitise inputs here
 	kubectlCmd := exec.Command( //nolint:gosec
 		"kubectl",
 		"--kubeconfig",
 		kubeconfig,
 		"-n",
-		mainNamespace,
+		namespace,
 		"scale",
 		deploymentType,
 		deploymentName,
@@ -165,7 +164,7 @@ func Scale(kubeconfig string, deploymentName string, deploymentType string, repl
 	return nil
 }
 
-func DeleteMainNamespace(kubeconfig string) error {
+func DeleteMainNamespace(kubeconfig string, namespace string) error {
 	// TODO: sanitise inputs here
 	kubectlCmd := exec.Command( //nolint:gosec
 		"kubectl",
@@ -173,7 +172,7 @@ func DeleteMainNamespace(kubeconfig string) error {
 		kubeconfig,
 		"delete",
 		"namespace",
-		mainNamespace,
+		namespace,
 	)
 	kubectlOut, err := kubectlCmd.CombinedOutput()
 	if zerolog.GlobalLevel() == zerolog.DebugLevel {
@@ -195,14 +194,14 @@ type statefulset struct {
 	} `json:"status"`
 }
 
-func GetScale(kubeconfig string, deploymentName string) (int, error) {
+func GetScale(kubeconfig string, deploymentName string, namespace string) (int, error) {
 	// TODO: sanitise inputs here
 	kubectlCmd := exec.Command( //nolint:gosec
 		"kubectl",
 		"--kubeconfig",
 		kubeconfig,
 		"-n",
-		mainNamespace,
+		namespace,
 		"get",
 		"statefulset",
 		deploymentName,

--- a/pkg/lightningnode/lightningnode.go
+++ b/pkg/lightningnode/lightningnode.go
@@ -48,8 +48,9 @@ type CLNConnectionFiles struct {
 }
 
 type LightningNode struct {
-	Name string
-	Impl NodeImpl
+	Name      string
+	Impl      NodeImpl
+	Namespace string
 }
 
 func (n *LightningNode) GetName() string {
@@ -209,6 +210,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 			kubeConfig,
 			fmt.Sprintf("%v-0:root/.lnd/tls.cert", n.Name),
 			path.Join(dir, "tls.cert"),
+			n.Namespace,
 		)
 		if err != nil {
 			return errors.Wrap(err, "KubeCP LND's tls.cert")
@@ -217,6 +219,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 			kubeConfig,
 			fmt.Sprintf("%v-0:root/.lnd/data/chain/bitcoin/%v/admin.macaroon", n.Name, network),
 			path.Join(dir, "admin.macaroon"),
+			n.Namespace,
 		)
 		if err != nil {
 			return errors.Wrap(err, "KubeCP LND's admin.macaroon")
@@ -226,6 +229,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 			kubeConfig,
 			fmt.Sprintf("%v-0:root/.lightning/%v/client.pem", n.Name, network),
 			path.Join(dir, "client.pem"),
+			n.Namespace,
 		)
 		if err != nil {
 			return errors.Wrap(err, "KubeCP CLN's client.pem")
@@ -234,6 +238,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 			kubeConfig,
 			fmt.Sprintf("%v-0:root/.lightning/%v/client-key.pem", n.Name, network),
 			path.Join(dir, "client-key.pem"),
+			n.Namespace,
 		)
 		if err != nil {
 			return errors.Wrap(err, "KubeCP CLN's client-key.pem")
@@ -242,6 +247,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 			kubeConfig,
 			fmt.Sprintf("%v-0:root/.lightning/%v/ca.pem", n.Name, network),
 			path.Join(dir, "ca.pem"),
+			n.Namespace,
 		)
 		if err != nil {
 			return errors.Wrap(err, "KubeCP CLN's ca.pem")
@@ -251,7 +257,7 @@ func (n *LightningNode) WriteAuthFilesToDirectory(network string, kubeConfig str
 }
 
 func (n *LightningNode) GetConnectionPort(kubeConfig string) (uint16, error) {
-	port, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-grpc", kube.ModeTCP)
+	port, err := kube.GetEndpointForNode(kubeConfig, n.Name+"-direct-grpc", kube.ModeTCP, n.Namespace)
 	if err != nil {
 		return 0, errors.Wrapf(err, "Getting endpoint for %v", n.Name)
 	}

--- a/pkg/tools/retry_test.go
+++ b/pkg/tools/retry_test.go
@@ -20,7 +20,7 @@ func TestRetry(t *testing.T) {
 	err := Retry(func(cancel context.CancelFunc) error {
 		retryCount++
 		return errors.New("Rando error")
-	}, 1*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Millisecond, 100*time.Millisecond)
 	assert.NotNil(err)
 
 	assert.Greater(retryCount, 2, "Function should have run at least a few times")
@@ -37,7 +37,7 @@ func TestRetryWithReturn(t *testing.T) {
 	returnVal, err := RetryWithReturn(func(cancel context.CancelFunc) (string, error) {
 		retryCount++
 		return "", errors.New("Rando error")
-	}, 1*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Millisecond, 100*time.Millisecond)
 	assert.NotNil(err)
 	assert.Empty(returnVal)
 	assert.Greater(retryCount, 2, "Function should have run at least a few times")


### PR DESCRIPTION
Allow different kubernetes namespaces for scaling lightning.

- !! Introduces **breaking change** for anyone running SL as GO package. Functions _NewSLNetwork_ and _DiscoverRunningNetwork_ now require namespace as parameter
- For running from CLI, no breaking change. The default namespace is SL.
  - But using different namespaces is supported by giving -N flag.
  - The -N flag should not be used in create command, since the namespace is read from the helmfile